### PR TITLE
New: More metadata included in manifests.

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -81,7 +81,8 @@ def create_manifest(identifier, domain=None):
                 }
             ],
         'viewingHint': 'paged',
-        'attribution': "The Internet Archive"
+        'attribution': "The Internet Archive",
+        'seeAlso': '%s/metadata/%s' % (ARCHIVE, identifier)
     }
     path = os.path.join(media_root, identifier)
     resp = requests.get('%s/metadata/%s' % (ARCHIVE, identifier)).json()


### PR DESCRIPTION
Wrote some small improvements to add more of the metadata
sourced from archive.org in the manifest response.

A `metadata` list will be generated by iterating through a new
top level `METADATA_FIELDS` tuple and adding any of the found
values to the manifest.

Descriptions and links back to the internet archive are also
included in the manifest that is produced.