### PR TITLE
fix /iiif & catalog.json

### DIFF
--- a/iiify/resolver.py
+++ b/iiify/resolver.py
@@ -16,14 +16,20 @@ valid_filetypes = ['jpg', 'jpeg', 'png', 'gif', 'tif', 'jp2', 'pdf']
 def purify_domain(domain):
     return domain if domain.endswith('/iiif/') else domain + 'iiif/'
 
-def getids(q, limit=1000, cursor=''):
-    r = requests.get('%s/iiif' % apiurl, params={
-        'q': q,
-        'limit': limit,
-        'cursor': cursor
-    }, allow_redirects=True, timeout=None)
-    return r.json()
-
+def getids(query, page=1, limit=100, security=True, sort='', fields='identifier,title'):
+    limit = min(limit, 1000)
+    params = {
+        'q': query,
+        'rows': limit,
+        'sort': sort,
+        'page': page,
+        'fl[]': fields,
+        'output': 'json',
+    }
+    return requests.get(
+        "%s/advancedsearch.php" % ARCHIVE, params=params,
+        allow_redirects=True, timeout=None
+    ).json()
 
 def collection(domain, identifiers, label='Custom Archive.org IIIF Collection'):
     cs = {


### PR DESCRIPTION
Fixes `/iiif` to show IDs of all eligible items. Can be customized with `?q=`

Also fixes collection querying / synthesis `https://iiif.archivelab.org/iiif/collection.json?q=collection:inlibrary`