### PR TITLE
Test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Navigate to http://127.0.0.1:8080/iiif
 
 ## Test it!
 
+Unit tests are in the `tests` folder and can be run with:
+```
+python -m unittest discover -s tests
+```
+
 Retrieve large.jpg as 800px wide JPEG
 * http://127.0.0.1:8080/iiif/large.jpg/full/800,/0/default.jpg 
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,22 @@ A simple Python Flask-based implementation of the IIIF Image API 1.0 standard
 git clone https://github.com/ArchiveLabs/iiif.archivelab.org.git
 cd iiif.archivelab.org
 pip install .
-cd iiify
 python app.py
 ```
-Navigate to http://127.0.0.1:8080
+Navigate to http://127.0.0.1:8080/iiif
+
+You can also run the app using Docker, either with the Flask development server:
+```
+docker build -t iiify .
+docker run -d --rm --name iiify -p 8080:8080 iiify
+```
+or with an image using nginx and uwsgi:
+```
+docker build -t iiify-uwsgi -f Dockerfile-uwsgi .
+docker run -d --rm --name iiify -p 8080:8080 iiify-uwsgi
+```
+
+Navigate to http://127.0.0.1:8080/iiif
 
 ## Test it!
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,18 @@
+import unittest
+from flask.testing import FlaskClient
+from iiify.app import app
+
+
+class TestBasic(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.test_app = FlaskClient(app)
+
+    def test_documentation(self):
+        resp = self.test_app.get("/iiif/documentation")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.text[:15], "<!doctype html>")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,28 @@
+import unittest
+from iiify.resolver import purify_domain, collection, manifest_page
+
+class TestResolver(unittest.TestCase):
+    def test_purify(self):
+        domain = purify_domain("https://example.org/iiif/")
+        self.assertEqual(domain, "https://example.org/iiif/")
+        domain = purify_domain("https://example.org/test/")
+        self.assertEqual(domain, "https://example.org/test/iiif/")
+
+    def test_collection(self):
+        coll = collection(domain="https://example.org/", identifiers=["1", "2", "3"])
+        self.assertIsInstance(coll, dict)
+        self.assertEqual(coll["@id"], "https://example.org/collection.json")
+        self.assertEqual(len(coll["collections"]), 3)
+        self.assertEqual(coll["collections"][0]["@id"], "https://example.org/1/manifest.json")
+
+    def test_manifest_page(self):
+        mani = manifest_page(identifier="https://example.org/1", label="p1", width=100, height=100)
+        self.assertEqual(mani["@id"], "https://example.org/1/canvas")
+        self.assertEqual(mani['label'], 'p1')
+        self.assertEqual(mani["images"][0]["@id"], "https://example.org/1/annotation")
+        self.assertEqual(mani["images"][0]["resource"]["@id"], "https://example.org/1/full/full/0/default.jpg")
+        self.assertEqual(mani["images"][0]["resource"]["height"], 100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds:
- a basic test harness using python's internal `unittest` module
- a closer-to-integration-than-unit test to provide an example of how to call the endpoints using a Flask test client
- a couple of trivial-ish unit tests for the resolver module that may or may not survive (depending on how we restructure the v2 provision) but at least provide a jumping off point for the suite
- a section in the README with the instructions for running the test suite

I didn't write tests for anything requiring a connection to the IA servers because a) I was mid-air and so couldn't test it, and b) We should probably have a discussion about whether we want to use a VCR-like library for these.

This is the last part of the baseline ticket and so:
Closes #72 