### PR TITLE
Initial Cantaloupe forward

### DIFF
--- a/iiify/configs/__init__.py
+++ b/iiify/configs/__init__.py
@@ -64,3 +64,6 @@ apiurl = config.getdef('api', 'url', "https://api.archivelab.org")
 # url2iiif
 s3key = config.getdef('url2iiif', 's3key', '')
 s3secret = config.getdef('url2iiif', 's3secret', '')
+
+# cantaloupe server
+image_server = config.getdef('cantaloupe', 'url', '')


### PR DESCRIPTION
This PR replaces the existing image server endpoints with HTTP redirects to a Cantaloupe (or other!) service defined in the config file.

At the moment it is using HTTP 302 Found, but once the service is in production, it might be worth thinking about changing this to HTTP 301 Moved Permanently to encourage clients not to keep hitting the old address.